### PR TITLE
Password is getting exposed when using a password input type

### DIFF
--- a/src/Widgets/TextWidget.php
+++ b/src/Widgets/TextWidget.php
@@ -25,9 +25,14 @@ class TextWidget extends BaseWidget
 
         $fieldConfig['attributes'] = array_merge($fieldConfig['attributes'], $typeAttributes);
 
+        $safeValue = $value;
+        if ($fieldConfig['attributes']['type'] === 'password') {
+            $safeValue = '';
+        }
+
         return [
             'name' => $name,
-            'value' => old($name, $value),
+            'value' => old($name, $safeValue),
             'label' => $fieldConfig['label'] ?? null,
             'config' => $fieldConfig,
             'errors' => $errors,


### PR DESCRIPTION
This PR adds a filter to TextWidget, when the type of the input is password it resets the value to prevent leaks